### PR TITLE
Homework11

### DIFF
--- a/HW11/README.MD
+++ b/HW11/README.MD
@@ -1,0 +1,1 @@
+# (12) Workshop todolist

--- a/HW11/index.css
+++ b/HW11/index.css
@@ -1,0 +1,3 @@
+ul {
+    list-style-type: none;
+}

--- a/HW11/index.css
+++ b/HW11/index.css
@@ -1,3 +1,143 @@
-ul {
-    list-style-type: none;
+/* index.css */
+
+/* General styles */
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    margin: 0;
+    padding: 0;
+  }
+  
+  .container {
+    width: 50%;
+    margin: auto;
+    padding: 20px;
+    background: #fff;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  h3.task-title {
+    margin-bottom: 20px;
+    color: #333;
+    text-align: left;
+  }
+  
+  /* Form styles */
+  /* .create-task-block, .filter-task-block {
+    margin-bottom: 0px;
+  } */
+  
+  .create-task-form, .filter-task-block {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .input-field {
+    margin-bottom: 10px;
+  }
+  
+  input[type="text"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+  
+  .btn, .clear-tasks {
+    background: #333;
+    color: #fff;
+    padding: 10px;
+    border: none;
+    cursor: pointer;
+    border-radius: 4px;
+    text-align: center;
+  }
+  
+  .btn:hover, .clear-tasks:hover {
+    background: #555;
+  }
+  
+  /* Fixed elements */
+  .create-task-block,
+  .filter-task-block {
+    position: fixed;
+    top: 0;
+    width: calc(50% - 40px); /* Adjust based on container width and padding */
+    background-color: #fff;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    padding: 20px;
+  }
+  
+  /* Push the filter block below the create block */
+  .filter-task-block {
+    top: 160px; /* Adjust based on the height of .create-task-block */
+  }
+  
+  /* Adjust container padding for fixed elements */
+  .container {
+    padding-top: 220px; /* Adjust based on combined height of fixed blocks */
+  }
+  
+  /* Task list styles */
+  .filter-task-block {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    margin-top: 5px;
+  }
+  
+  ul.collection {
+    list-style: none;
+    padding: 0;
+    flex-grow: 1;
+    overflow-y: auto; /* Enable vertical scrolling */
+    height: 350px; /* Set a specific height for the list */
+
+  }
+  
+  li.collection-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-bottom: 10px;
+    background: #fff;
+  }
+  
+  li.collection-item .text-with-icon {
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+  }
+  
+  li.collection-item .text-with-icon i {
+    margin-right: 10px;
+  }
+  
+  span.delete-item {
+    color: red;
+    cursor: pointer;
+  }
+  
+  span.delete-item:hover {
+    color: darkred;
+  }
+  
+  /* "DELETE ALL" button fixed */
+  .clear-tasks {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 50%;
 }
+
+  

--- a/HW11/index.html
+++ b/HW11/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="index.css">
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <title>Список завдань</title>
+</head>
+<body>
+<div class="container">
+
+  <div class="create-task-block">
+    <form class="create-task-form">
+      <h3 class="task-title">Нове завдання</h3>
+      <div class="input-field">
+        <label>
+          <input type="text" name="task" class="task-input">
+        </label>
+      </div>
+      <button type="submit" class="btn">Додати завдання</button>
+    </form>
+  </div>
+
+
+  <div class="filter-task-block">
+    <h3 class="task-title">Список завдань</h3>
+    <div class="input-field">
+      <label>
+        <input type="text" name="filter" class="filter-input" placeholder="Пошук завдань">
+      </label>
+    </div>
+    <ul class="collection"></ul>
+    <button class="clear-tasks">Видалити всі завдання</button>
+  </div>
+
+</div>
+<script src='index.js'></script>
+</body>
+</html>

--- a/HW11/index.html
+++ b/HW11/index.html
@@ -16,7 +16,7 @@
       <h3 class="task-title">Нове завдання</h3>
       <div class="input-field">
         <label>
-          <input type="text" name="task" class="task-input">
+          <input type="text" name="task" class="task-input" placeholder="Завдання">
         </label>
       </div>
       <button type="submit" class="btn">Додати завдання</button>

--- a/HW11/index.js
+++ b/HW11/index.js
@@ -4,7 +4,7 @@ const taskInput = document.querySelector('.task-input');
 const tasksList = document.querySelector('.collection');
 const clearAllBtn = document.querySelector('.clear-tasks');
 const form = document.querySelector('.create-task-form');
-let taskId = 0;
+const search = document.querySelector('.filter-input');
 
 //завантаження інформації при завантаженні сторінки
 document.addEventListener('DOMContentLoaded', updateTasksList);
@@ -29,7 +29,7 @@ form.addEventListener('submit', (event) => {
         return;
     }
 
-    ++taskId;
+    const taskId = Date.now();
     const task = {
         id: taskId,
         task: taskInput.value
@@ -89,12 +89,12 @@ tasksList.addEventListener('click', function(event) {
     const taskId = parseInt(task.dataset.id);
     const tasks = localStorage.getItem('tasks') !== null
         ? JSON.parse(localStorage.getItem('tasks')) : [];
-
+    //видалення
     if (event.target.closest('.delete-item')) {
         tasksList.removeChild(task);
         const updatedTasks = tasks.filter(task => task.id !== taskId)
         localStorage.setItem('tasks', JSON.stringify(updatedTasks));
-
+    //редагування
     } else if (event.target.closest('.edit-item')) {
         let editedTask = prompt('Редагування завдання', task.textContent);
         if (editedTask === null || editedTask.trim() === '') {
@@ -108,4 +108,19 @@ tasksList.addEventListener('click', function(event) {
         };
     }   
 });
+ 
+//пошук
+search.addEventListener('input', findTasks);
+function findTasks(){
+    let tasks = tasksList.querySelectorAll('li');
+    for (let i = 0; i < tasks.length; i++) {
+        if (tasks[i].childNodes[1].nodeValue.indexOf(search.value) > -1) {
+            tasks[i].style.display = '';
+        } else {
+            tasks[i].style.display = 'none';
+        }
+    };
+};
+
+
 

--- a/HW11/index.js
+++ b/HW11/index.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const taskInput = document.querySelector('.task-input');
+const tasksList = document.querySelector('.collection');
+const clearAllBtn = document.querySelector('.clear-tasks');
+const form = document.querySelector('.create-task-form');
+let taskId = 0;
+
+//завантаження інформації при завантаженні сторінки
+document.addEventListener('DOMContentLoaded', updateTasksList);
+
+function updateTasksList () {
+    //очищуємо список
+    tasksList.innerHTML = '';
+
+    const tasks = localStorage.getItem('tasks') !== null
+        ? JSON.parse(localStorage.getItem('tasks')) : [];
+
+    tasks.forEach((task) => {
+        createSingleTaskElement(task);
+    });
+};
+
+form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    if (taskInput.value.trim() === '') {
+        taskInput.value = '';
+        return;
+    }
+
+    ++taskId;
+    const task = {
+        id: taskId,
+        task: taskInput.value
+    };
+
+    createSingleTaskElement(task);
+    storeTaskInLocalStorage(task);
+    taskInput.value = '';
+});
+
+
+
+// створення окремого елементу списку завдань + кнопок взаємодії з ним
+function createSingleTaskElement(task) {
+    const li = document.createElement('li');
+    li.className = 'collection-item'; 
+    li.dataset.id = task.id;
+
+    //кнопка редагування
+    const editElement = document.createElement('span');
+    editElement.className = 'edit-item';
+    editElement.innerHTML = '  <i class="fa fa-edit"></i> ';
+    li.appendChild(editElement);
+
+    //текст завдання 
+    li.appendChild(document.createTextNode(task.task));
+
+    //кнопка видалення
+    const deleteElement = document.createElement('span');
+    deleteElement.className = 'delete-item';
+    deleteElement.innerHTML = ' <i class="fa fa-remove"></i> ';
+    li.appendChild(deleteElement);
+    
+    //додавання завдання в загальний список завдань
+    tasksList.appendChild(li);
+}
+
+//зберігання завдань в локал сторедж
+function storeTaskInLocalStorage(task) {
+    const tasks = localStorage.getItem('tasks') !== null
+        ? JSON.parse(localStorage.getItem('tasks')) : [];
+    tasks.push(task);
+    localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+//видалення всіх завдань
+clearAllBtn.addEventListener('click', () => {
+    if (confirm('Are you sure?')) {
+        localStorage.removeItem('tasks');
+        tasksList.innerHTML = '';
+    }
+})
+
+//видалення/редагування однієї задачі
+tasksList.addEventListener('click', function(event) {
+    const task = event.target.closest('li');
+    const taskId = parseInt(task.dataset.id);
+    const tasks = localStorage.getItem('tasks') !== null
+        ? JSON.parse(localStorage.getItem('tasks')) : [];
+
+    if (event.target.closest('.delete-item')) {
+        tasksList.removeChild(task);
+        const updatedTasks = tasks.filter(task => task.id !== taskId)
+        localStorage.setItem('tasks', JSON.stringify(updatedTasks));
+
+    } else if (event.target.closest('.edit-item')) {
+        let editedTask = prompt('Редагування завдання', task.textContent);
+        if (editedTask === null || editedTask.trim() === '') {
+            return;
+        } else {
+            editedTask = editedTask.trim();
+            task.childNodes[1].nodeValue = editedTask;
+            const updatedTasks = tasks.map(task =>
+                task.id === taskId ? {...task, task: editedTask} : task);
+            localStorage.setItem('tasks', JSON.stringify(updatedTasks));
+        };
+    }   
+});
+


### PR DESCRIPTION
Виправити помилку з видаленням завдання


Наразі у програми є проблема з видаленням окремих елементів, якщо у списку є завдання з однаковими текстами. 

Наприклад, у вас є наступний список завдань:

Поїсти Поспати Сходити в зал Поїсти Поспати Сходити в офіс Поїсти Поспати Піти додому

Якщо юзер видалить друге завдання 'Поїсти' (яке йде після 'Сходити в зал'), то на сторінці все видалиться коректно, проте у локалСтораджі видаляться всі завдання 'Поїсти'.


Зробіть так, аби функціонал видалення працював коректно — тобто аби при видалені на сторінці з локалСтораджу видалявся саме той елемент який видалив юзер, а не якісь ще крім нього.

Для цього можете використати кастомні атрибути (https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) і/або індекс елементу і методи масивів та приведення до масивів


Додати можливість оновлювати окреме завдання

Зробіть так аби юзер крім видалення окремого елементу мав ще й можливість редагувати текст окремого завдання.

Для цього можете додати іконку з олівцем поруч з іконкою для видалення.

Приклад елементу:

<i class="fa fa-edit"></i>

  Для самого функціоналу можете використати вбудоване діалогове вікно (https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt), а також індекс елементу і методи масивів та приведення до масивів  

Додати всій сторінці стилів

Додайте сторінці візуальної унікальності через css класи